### PR TITLE
refactor dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,37 @@
 FROM debian:stretch-slim
 LABEL  maintainer="mle@counterflowai.com" domain="counterflow.ai"
-
-RUN apt-get update --fix-missing
-RUN apt-get install -y zlib1g-dev libluajit-5.1 liblua5.1-dev lua-socket libcurl4-openssl-dev libatlas-base-dev libhiredis-dev git make
 #
+# Install dependencies
 #
+RUN apt update --fix-missing
+RUN apt install -y zlib1g-dev libluajit-5.1 liblua5.1-dev lua-socket libcurl4-openssl-dev libatlas-base-dev libhiredis-dev git make libmicrohttpd-dev
 #
-#RUN git clone https://github.com/counterflow-ai/dragonfly-mle; \
-RUN git clone -b devel https://github.com/counterflow-ai/dragonfly-mle; \
-    cd dragonfly-mle/src; make ; make install
-RUN rm -rf dragonfly-mle
+# Build dragonfly-mle
+#
+COPY ./ /tmp/dragonfly-mle
+WORKDIR /tmp/dragonfly-mle/src
+RUN make && make install
 #
 # Build redis
 #
-RUN git clone https://github.com/antirez/redis.git; \
-    cd redis/src; make ; make install
-RUN rm -rf redis
+RUN git clone https://github.com/antirez/redis /tmp/redis
+WORKDIR /tmp/redis/src
+RUN make && make install
 #
 # Build redis ML
 #
-RUN git clone https://github.com/RedisLabsModules/redis-ml.git; \
-    cd redis-ml/src; \
-    make ; \
-    mkdir /usr/local/lib ; \
-    cp redis-ml.so /usr/local/lib
-RUN rm -rf redis-ml
+RUN git clone https://github.com/RedisLabsModules/redis-ml /tmp/redis-ml
+WORKDIR /tmp/redis-ml/src
+RUN make
+RUN cp redis-ml.so /usr/local/lib
 #
+# Cleanup/Maintainance 
 #
+RUN rm -rf /tmp/*
+RUN mkdir -p /opt/suricata/var
+RUN apt purge -y build-essential git make && apt -y autoremove
 #
-RUN mkdir /opt/suricata/; mkdir /opt/suricata/var
-RUN apt-get purge -y build-essential git make; apt-get autoremovecd 
+# Entry
 #
 WORKDIR /usr/local/dragonfly-mle
 ENTRYPOINT redis-server --loadmodule /usr/local/lib/redis-ml.so --daemonize yes && /usr/local/dragonfly-mle/bin/dragonfly-mle


### PR DESCRIPTION
Previously all branches of `dragonfly-mle` were ONLY cloning down the devel branch when making a docker builds. So it didn't matter whether you were on `master` or `xyz` you still would have made a devel branch docker build. I've refactored the `Dockerfile` code to self-copy it's self rather than making a call for the repo.

This will allow you to create docker builds according to the current branch and also help with development purposes if you wanted to do quick modifications and wanted to rebuild the image from your working directory.