### PR TITLE
Add base loop timing and Redis benchmark

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,11 @@ add_executable(dragonfly-bench
         benchmark/bench1.c
         benchmark/bench2.c
         benchmark/bench3.c
+        benchmark/bench4.c
+        benchmark/bench5.c
+        benchmark/bench6.c
         ${SOURCE_FILES})
 
-add_executable(dragonfly-mle main.c ${SOURCE_FILES})
+add_executable(dragonfly-mle
+        main.c
+        ${SOURCE_FILES})

--- a/src/Makefile
+++ b/src/Makefile
@@ -61,7 +61,10 @@ SRCS4 = test/test.c test/test0.c test/test1.c test/test2.c \
 # ------------------------------------------------------------------
 # benchmarking files
 # ------------------------------------------------------------------
-SRCS5 = benchmark/benchmark.c benchmark/bench0.c benchmark/bench1.c benchmark/bench2.c benchmark/bench3.c
+SRCS5 = benchmark/benchmark.c \
+		benchmark/bench0.c benchmark/bench1.c benchmark/bench2.c \
+		benchmark/bench3.c benchmark/bench4.c benchmark/bench5.c \
+		benchmark/bench6.c
 
 
 MAIN_OBJS = $(MAIN_SRC:.c=.o) $(SRCS0:.c=.o) $(SRCS1:.c=.o) $(SRCS2:.c=.o) $(SRCS3:.c=.o)

--- a/src/benchmark/bench0.c
+++ b/src/benchmark/bench0.c
@@ -42,16 +42,15 @@
 
 static const char *CONFIG_LUA =
 	"inputs = {\n"
-	"   { tag=\"input\", uri=\"ipc://input.ipc\", script=\"filter.lua\", default_analyzer=\"bench0\"}\n"
+	"   { tag=\"LUAinput\", uri=\"ipc://input.ipc\", script=\"filter.lua\", default_analyzer=\"bench0\"}\n"
 	"}\n"
 	"\n"
 	"analyzers = {\n"
-	"    { tag=\"bench0\", script=\"analyzer.lua\", default_analyzer=\"\", default_output=\"log0\" },\n"
+	"    { tag=\"bench0-analyzer\", script=\"analyzer.lua\", default_analyzer=\"\", default_output=\"bench0-log\" },\n"
 	"}\n"
 	"\n"
 	"outputs = {\n"
-    "    { tag=\"log0\", uri=\"file:///dev/null\"},\n"
-//    "    { tag=\"log0\", uri=\"file:///tmp/benchmark.log\"},\n"
+    "    { tag=\"bench0-log\", uri=\"file:///dev/null\"},\n"
 	"}\n"
 	"\n";
 
@@ -60,7 +59,6 @@ static const char *INPUT_LUA =
 	"end\n"
 	"\n"
 	"function loop(msg)\n"
-//	"   dragonfly.analyze_event(default_analyzer, msg)\n"
   "   -- do nothing\n"
 	"end\n";
 
@@ -68,7 +66,6 @@ static const char *ANALYZER_LUA =
 	"function setup()\n"
 	"end\n"
 	"function loop (msg)\n"
-//	"  dragonfly.output_event (default_output, msg)\n"
     "  -- do nothing\n"
 	"end\n\n";
 /*
@@ -109,7 +106,7 @@ void SELF_BENCH0(const char *dragonfly_root)
 	signal(SIGPIPE, SIG_IGN);
 	openlog("dragonfly", LOG_PERROR, LOG_USER);
 #ifdef _GNU_SOURCE
-	pthread_setname_np(pthread_self(), "dragonfly");
+	pthread_setname_np(pthread_self(), "bench0-dragonfly");
 #endif
 	initialize_configuration(dragonfly_root, dragonfly_root, dragonfly_root);
 	startup_threads();
@@ -139,7 +136,7 @@ void SELF_BENCH0(const char *dragonfly_root)
 			clock_t mark_time = clock();
 			double elapsed_time = ((double)(mark_time - last_time)) / CLOCKS_PER_SEC; // in seconds
 			double ops_per_sec = QUANTUM / elapsed_time;
-			fprintf(stdout, "\t%6.2f/sec\n", ops_per_sec);
+			fprintf(stdout, "%6.2f /sec\n", ops_per_sec);
 			last_time = clock();
 		}
 	}

--- a/src/benchmark/bench1.c
+++ b/src/benchmark/bench1.c
@@ -35,23 +35,21 @@
 #include <assert.h>
 
 #include "benchmark.h"
-#include "dragonfly-io.h"
 
-#define MAX_BENCH0_MESSAGES 100000
-#define QUANTUM (MAX_BENCH0_MESSAGES / 10)
+#define MAX_BENCH1_MESSAGES 100000
+#define QUANTUM (MAX_BENCH1_MESSAGES / 10)
 
 static const char *CONFIG_LUA =
 	"inputs = {\n"
-	"   { tag=\"input\", uri=\"ipc://input.ipc\", script=\"filter.lua\", default_analyzer=\"bench0\"}\n"
+	"   { tag=\"LUAinput\", uri=\"ipc://input.ipc\", script=\"filter.lua\", default_analyzer=\"bench1\"}\n"
 	"}\n"
 	"\n"
 	"analyzers = {\n"
-	"    { tag=\"bench0\", script=\"analyzer.lua\", default_analyzer=\"\", default_output=\"log0\" },\n"
+	"    { tag=\"bench1\", script=\"analyzer.lua\", default_analyzer=\"\", default_output=\"bench1-log\" },\n"
 	"}\n"
 	"\n"
 	"outputs = {\n"
-    "    { tag=\"log0\", uri=\"file:///dev/null\"},\n"
-//    "    { tag=\"log0\", uri=\"file:///tmp/benchmark.log\"},\n"
+    "    { tag=\"bench1-log\", uri=\"file:///dev/null\"},\n"
 	"}\n"
 	"\n";
 
@@ -96,7 +94,7 @@ static void write_file(const char *file_path, const char *content)
  */
 void SELF_BENCH1(const char *dragonfly_root)
 {
-	fprintf(stdout, "\n%s: pumping %d messages: input and no-op analyzer\n", __FUNCTION__, MAX_BENCH0_MESSAGES);
+	fprintf(stdout, "\n%s: pumping %d messages: input and no-op analyzer\n", __FUNCTION__, MAX_BENCH1_MESSAGES);
 	fprintf(stdout, "-------------------------------------------------------\n");
 	/*
 	 * generate lua scripts
@@ -109,7 +107,7 @@ void SELF_BENCH1(const char *dragonfly_root)
 	signal(SIGPIPE, SIG_IGN);
 	openlog("dragonfly", LOG_PERROR, LOG_USER);
 #ifdef _GNU_SOURCE
-	pthread_setname_np(pthread_self(), "dragonfly");
+	pthread_setname_np(pthread_self(), "bench1-dragonfly");
 #endif
 	initialize_configuration(dragonfly_root, dragonfly_root, dragonfly_root);
 	startup_threads();
@@ -125,7 +123,7 @@ void SELF_BENCH1(const char *dragonfly_root)
 
     char *msg = MSG;
 	clock_t last_time = clock();
-	for (unsigned long i = 0; i < MAX_BENCH0_MESSAGES; i++)
+	for (unsigned long i = 0; i < MAX_BENCH1_MESSAGES; i++)
 	{
 
 		if (dragonfly_io_write(pump, msg) < 0)
@@ -139,7 +137,7 @@ void SELF_BENCH1(const char *dragonfly_root)
 			clock_t mark_time = clock();
 			double elapsed_time = ((double)(mark_time - last_time)) / CLOCKS_PER_SEC; // in seconds
 			double ops_per_sec = QUANTUM / elapsed_time;
-			fprintf(stdout, "\t%6.2f/sec\n", ops_per_sec);
+			fprintf(stdout, "%6.2f /sec\n", ops_per_sec);
 			last_time = clock();
 		}
 	}

--- a/src/benchmark/bench4.c
+++ b/src/benchmark/bench4.c
@@ -1,0 +1,98 @@
+/* Copyright (C) 2017-2018 CounterFlow AI, Inc.
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/*
+ *
+ * author Don J. Rude <dr@counterflowai.com>
+ *
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <signal.h>
+#include <syslog.h>
+#include <pthread.h>
+#include <assert.h>
+
+#include <hiredis/hiredis.h>
+
+#include "benchmark.h"
+
+#define MAX_BENCH4_MESSAGES 100000
+#define QUANTUM (MAX_BENCH4_MESSAGES / 10)
+
+
+/*
+ * ---------------------------------------------------------------------------------------
+ *
+ * ---------------------------------------------------------------------------------------
+ */
+void SELF_BENCH4(const char *dragonfly_root)
+{
+	fprintf(stdout, "\n\n%s: sending %u ping messages to redis in a C-loop\n", __FUNCTION__, MAX_BENCH4_MESSAGES);
+	fprintf(stdout, "-------------------------------------------------------\n");
+
+	signal(SIGPIPE, SIG_IGN);
+	openlog("dragonfly", LOG_PERROR, LOG_USER);
+#ifdef _GNU_SOURCE
+	pthread_setname_np(pthread_self(), "dragonfly-bench4");
+#endif
+
+	sleep(1);
+
+    redisContext *pContext = redisConnect("127.0.0.1", 6379);
+
+    clock_t last_time = clock();
+	for (unsigned long i = 0; i < MAX_BENCH4_MESSAGES; i++)
+	{
+
+        redisReply *reply = redisCommand(pContext, "PING");
+
+        if ( reply == 0 || (reply->type == REDIS_REPLY_ERROR) || (strcasecmp(reply->str,"pong") != 0) )
+        {
+            fprintf(stderr,"Redis ping fail!\n");
+        }
+
+        freeReplyObject(reply);
+
+        if ((i > 0) && (i % QUANTUM) == 0)
+        {
+            clock_t mark_time = clock();
+            double elapsed_time = ((double)(mark_time - last_time)) / CLOCKS_PER_SEC; // in seconds
+            double ops_per_sec = QUANTUM / elapsed_time;
+            fprintf(stdout, "%6.2f /sec\n", ops_per_sec);
+            last_time = clock();
+        }
+	}
+    redisFree(pContext);
+
+	sleep(1);
+	closelog();
+
+	fprintf(stderr, "-------------------------------------------------------\n\n");
+	fflush(stderr);
+}
+
+/*
+ * ---------------------------------------------------------------------------------------
+ */

--- a/src/benchmark/bench6.c
+++ b/src/benchmark/bench6.c
@@ -1,0 +1,160 @@
+/* Copyright (C) 2017-2018 CounterFlow AI, Inc.
+ *
+ * You can copy, redistribute or modify this Program under the terms of
+ * the GNU General Public License version 2 as published by the Free
+ * Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * version 2 along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+ * 02110-1301, USA.
+ */
+
+/*
+ *
+ * author Don J. Rude <dr@counterflowai.com>
+ *
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <signal.h>
+#include <syslog.h>
+#include <pthread.h>
+#include <assert.h>
+
+#include <hiredis/hiredis.h>
+
+#include "benchmark.h"
+
+#define MAX_BENCH6_MESSAGES 200000
+#define QUANTUM (MAX_BENCH6_MESSAGES / 20)
+
+
+/*
+ * ---------------------------------------------------------------------------------------
+ *
+ * ---------------------------------------------------------------------------------------
+ */
+void SELF_BENCH6(const char *dragonfly_root)
+{
+	fprintf(stdout, "\n\n%s: sending %u SET messages to redis in a C-loop\n", __FUNCTION__, MAX_BENCH6_MESSAGES);
+	fprintf(stdout, "-------------------------------------------------------\n");
+
+	signal(SIGPIPE, SIG_IGN);
+	openlog("dragonfly", LOG_PERROR, LOG_USER);
+#ifdef _GNU_SOURCE
+	pthread_setname_np(pthread_self(), "dragonfly-bench6");
+#endif
+
+	sleep(1);
+
+    redisContext *pContext = redisConnect("127.0.0.1", 6379);
+
+    clock_t last_time = clock();
+	for (unsigned long i = 0; i < MAX_BENCH6_MESSAGES; i++)
+	{
+        char rcmd[100];
+        snprintf(rcmd, 100, "SET bench%lu %lu", i, i);
+        redisReply *reply = redisCommand(pContext, rcmd);
+
+        if ( reply == 0 || (reply->type == REDIS_REPLY_ERROR) )
+        {
+            fprintf(stderr,"Redis SET fail!\n");
+        }
+
+        freeReplyObject(reply);
+
+        if ((i > 0) && (i % QUANTUM) == 0)
+        {
+            clock_t mark_time = clock();
+            double elapsed_time = ((double)(mark_time - last_time)) / CLOCKS_PER_SEC; // in seconds
+            double ops_per_sec = QUANTUM / elapsed_time;
+            fprintf(stdout, "%6.2f /sec\n", ops_per_sec);
+            last_time = clock();
+        }
+	}
+
+    fprintf(stdout, "\n\n%s: sending %u GET messages to redis in a C-loop\n", __FUNCTION__, MAX_BENCH6_MESSAGES);
+    fprintf(stdout, "-------------------------------------------------------\n");
+
+    last_time = clock();
+    for (unsigned long i = 0; i < MAX_BENCH6_MESSAGES; i++)
+    {
+        char rcmd[100];
+        snprintf(rcmd, 100, "GET bench%lu", i);
+        redisReply *reply = redisCommand(pContext, rcmd);
+
+        if ( reply == 0 || (reply->type == REDIS_REPLY_ERROR) )
+        {
+            fprintf(stderr,"Redis 'GET bench%lu' fail!\n", i);
+        } else {
+            unsigned long rply = 0;
+            sscanf(reply->str, "%lu", &rply);
+            if( rply != i )
+                fprintf(stdout, "reply: '%s' no match i=%lu\n", reply->str, i);
+        }
+
+        freeReplyObject(reply);
+
+        if ((i > 0) && (i % QUANTUM) == 0)
+        {
+            clock_t mark_time = clock();
+            double elapsed_time = ((double)(mark_time - last_time)) / CLOCKS_PER_SEC; // in seconds
+            double ops_per_sec = QUANTUM / elapsed_time;
+            fprintf(stdout, "%6.2f /sec\n", ops_per_sec);
+            last_time = clock();
+        }
+    }
+
+
+    fprintf(stdout, "\n\n%s: sending %u DEL messages to redis in a C-loop\n", __FUNCTION__, MAX_BENCH6_MESSAGES);
+    fprintf(stdout, "-------------------------------------------------------\n");
+
+    last_time = clock();
+    for (unsigned long i = 0; i < MAX_BENCH6_MESSAGES; i++)
+    {
+        char rcmd[100];
+        snprintf(rcmd, 100, "DEL bench%lu", i);
+        redisReply *reply = redisCommand(pContext, rcmd);
+
+        if ( reply == 0 || (reply->type == REDIS_REPLY_ERROR) )
+        {
+            fprintf(stderr,"Redis 'DEL bench%lu' fail!\n", i);
+        }
+        freeReplyObject(reply);
+
+        if ((i > 0) && (i % QUANTUM) == 0)
+        {
+            clock_t mark_time = clock();
+            double elapsed_time = ((double)(mark_time - last_time)) / CLOCKS_PER_SEC; // in seconds
+            double ops_per_sec = QUANTUM / elapsed_time;
+            fprintf(stdout, "%6.2f /sec\n", ops_per_sec);
+            last_time = clock();
+        }
+    }
+
+
+    redisFree(pContext);
+
+	sleep(1);
+	closelog();
+
+	fprintf(stderr, "-------------------------------------------------------\n\n");
+	fflush(stderr);
+}
+
+/*
+ * ---------------------------------------------------------------------------------------
+ */

--- a/src/benchmark/benchmark.c
+++ b/src/benchmark/benchmark.c
@@ -34,11 +34,7 @@
 #include <pthread.h>
 #include <errno.h>
 
-#include "config.h"
 #include "benchmark.h"
-
-#include "dragonfly-lib.h"
-#include "dragonfly-io.h"
 
 #define WAIT_INTERVAL 1
 
@@ -76,6 +72,22 @@ void dragonfly_mle_bench(const char *dragonfly_root)
 	snprintf(config_dir, sizeof(config_dir), "%s/%s", dragonfly_root, CONFIG_DIR);
 	mkdir(config_dir, 0755);
 
+	fprintf(stdout,"Timing basic C-loop\n");
+    fprintf(stdout, "-------------------------------------------------------\n");
+    clock_t last_time = clock();
+    for (unsigned long i = 0; i < (1uL<<28); i++)
+    {
+
+        if ((i > 0) && (i % (1uL<<25) ) == 0)
+        {
+            clock_t mark_time = clock();
+            double elapsed_time = ((double)(mark_time - last_time)) / CLOCKS_PER_SEC; // in seconds
+            double ops_per_sec = 500000 / elapsed_time;
+            fprintf(stdout, "%6.2f /sec\n", ops_per_sec);
+            last_time = clock();
+        }
+    }
+
 	SELF_BENCH0(dragonfly_root);
 	sleep(WAIT_INTERVAL);
 
@@ -86,6 +98,15 @@ void dragonfly_mle_bench(const char *dragonfly_root)
     sleep(WAIT_INTERVAL);
 
     SELF_BENCH3(dragonfly_root);
+    sleep(WAIT_INTERVAL);
+
+    SELF_BENCH4(dragonfly_root);
+    sleep(WAIT_INTERVAL);
+
+    SELF_BENCH5(dragonfly_root);
+    sleep(WAIT_INTERVAL);
+
+    SELF_BENCH6(dragonfly_root);
     sleep(WAIT_INTERVAL);
 
     rmdir(analyzer_dir);

--- a/src/benchmark/benchmark.h
+++ b/src/benchmark/benchmark.h
@@ -25,8 +25,8 @@
 #define _BENCHMARK_H_
 
 
-#include "dragonfly-lib.h"
-#include "dragonfly-io.h"
+#include "../dragonfly-lib.h"
+#include "../dragonfly-io.h"
 
 
 #define ANALYZER_TEST_FILE "analyzer/analyzer.lua"
@@ -39,4 +39,7 @@ void SELF_BENCH0(const char *dragonfly_root);
 void SELF_BENCH1(const char *dragonfly_root);
 void SELF_BENCH2(const char *dragonfly_root);
 void SELF_BENCH3(const char *dragonfly_root);
+void SELF_BENCH4(const char *dragonfly_root);
+void SELF_BENCH5(const char *dragonfly_root);
+void SELF_BENCH6(const char *dragonfly_root);
 #endif

--- a/src/main-bench.c
+++ b/src/main-bench.c
@@ -21,6 +21,10 @@
  *
  */
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <sys/un.h>
 #include <string.h>
 #include <stdlib.h>
@@ -60,7 +64,7 @@ int main(int argc, char **argv)
 {
 	
 #ifdef _GNU_SOURCE
-	pthread_setname_np(pthread_self(), "dragonfly");
+	pthread_setname_np(pthread_self(), "dragonfly-main");
 #endif
 
 	openlog("dragonfly", LOG_PERROR, LOG_USER);


### PR DESCRIPTION
Squashed commit of the following:

Date:   Mon May 6 18:43:28 2019 -0400
    bench6: More Redis testing (c-loops)

Date:   Mon May 6 09:41:03 2019 -0400
    reformat whitespace in output

Date:   Mon May 6 09:37:21 2019 -0400
    reformat whitespace in output

Date:   Fri May 3 16:47:49 2019 -0400
    move 4 to 5, add base timing loop, make 4 a c-loop

Date:   Fri May 3 15:10:00 2019 -0400
    Some naming cleanup plus new bench4